### PR TITLE
chore: add `vercel.json`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
#94 

### Short description
Vercel config missing. Rewrites everything to `index.html`.
