### PR TITLE
feat: add `closable` prop for card components

### DIFF
--- a/src/lib/card/Card.svelte
+++ b/src/lib/card/Card.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import Button from "../button/Button.svelte";
   import IconButton from "../button/IconButton.svelte";
   import CloseIcon from "../icons/CloseIcon.svelte";
 
@@ -8,53 +7,52 @@
   export let description: string;
   export let imageSrc: string = "";
   export let imageDescription: string = "Card image";
-  export let showAction: boolean = false;
-  export let actionLabel: string = "Action";
-  export let showCancelAction: boolean = false;
+  export let closable: boolean = false;
+
+  let closed: boolean = false;
 
   const dispatch = createEventDispatcher();
 
-  function handleActionButtonClick() {
-    dispatch("action");
-  }
-
-  function handleCancelActionClick() {
-    dispatch("cancel");
+  function onClose() {
+    closed = true;
+    dispatch("close");
   }
 </script>
 
-<div class="proi-card">
-  {#if imageSrc}
-    <div
-      class="proi-card-image"
-      style:background-image="url({imageSrc})"
-      title={imageDescription}
-    />
-  {/if}
-  {#if title}
-    <h2 class="proi-card-title">{title}</h2>
-  {/if}
-  {#if description}
-    <div class="proi-card-description">{description}</div>
-  {/if}
-  {#if showAction}
-    <div class="proi-card-actions">
-      <Button
-        block
-        on:click={handleActionButtonClick}
+{#if !closed}
+  <div class="proi-card">
+    {#if title}
+      <h2
+        class="proi-card-title"
+        style:justify-content={closable ? "space-between" : "flex-start"}
       >
-        {actionLabel}
-      </Button>
-      {#if showCancelAction}
-        <IconButton
-          variant="danger"
-          icon={CloseIcon}
-          on:click={handleCancelActionClick}
-        />
-      {/if}
-    </div>
-  {/if}
-</div>
+        {title}
+        {#if closable}
+          <IconButton
+            icon={CloseIcon}
+            variant="ghost"
+            on:click={onClose}
+          />
+        {/if}
+      </h2>
+    {/if}
+    {#if imageSrc}
+      <div
+        class="proi-card-image"
+        style:background-image="url({imageSrc})"
+        title={imageDescription}
+      />
+    {/if}
+    {#if description}
+      <div class="proi-card-description">{description}</div>
+    {/if}
+    {#if $$slots.actions}
+      <div class="proi-card-actions">
+        <slot name="actions" />
+      </div>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .proi-card {
@@ -70,6 +68,9 @@
   }
 
   .proi-card-title {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
     font-size: 16px;
     margin: 0;
   }
@@ -88,6 +89,7 @@
   .proi-card-actions {
     margin-top: 4px;
     display: flex;
+    flex-direction: row;
     gap: 4px;
   }
 
@@ -97,5 +99,12 @@
 
   .proi-card-actions :global(.proi-icon-button svg path) {
     stroke: var(--n0);
+  }
+
+  /* Close button */
+  .proi-card-title :global(.proi-icon-button) {
+    position: absolute;
+    right: 0;
+    top: 2px;
   }
 </style>

--- a/src/lib/card/Card.svelte
+++ b/src/lib/card/Card.svelte
@@ -87,18 +87,11 @@
   }
 
   .proi-card-actions {
-    margin-top: 4px;
+    margin-top: 8px;
     display: flex;
     flex-direction: row;
+    justify-content: space-around;
     gap: 4px;
-  }
-
-  .proi-card-actions :global(.proi-icon-button) {
-    width: 32px;
-  }
-
-  .proi-card-actions :global(.proi-icon-button svg path) {
-    stroke: var(--n0);
   }
 
   /* Close button */

--- a/src/lib/card/Card.svelte
+++ b/src/lib/card/Card.svelte
@@ -68,6 +68,7 @@
   }
 
   .proi-card-title {
+    color: var(--n800);
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -83,6 +84,7 @@
   }
 
   .proi-card-description {
+    color: var(--n800);
     font-size: 12px;
   }
 

--- a/src/lib/card/FillCard.svelte
+++ b/src/lib/card/FillCard.svelte
@@ -1,19 +1,47 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import IconButton from "../button/IconButton.svelte";
+  import CloseIcon from "../icons/CloseIcon.svelte";
   import type { CardVariant } from "./card.types.js";
 
   export let title: string;
   export let description: string;
   export let variant: CardVariant = "pine";
+  export let closable: boolean = false;
+
+  let closed: boolean = false;
+
+  const dispatch = createEventDispatcher();
+
+  function onClose() {
+    closed = true;
+
+    dispatch("close");
+  }
 </script>
 
-<div class="proi-card data-display {variant}">
-  {#if title}
-    <h2 class="proi-card-title">{title}</h2>
-  {/if}
-  {#if description}
-    <div class="proi-card-description">{description}</div>
-  {/if}
-</div>
+{#if !closed}
+  <div class="proi-card data-display {variant}">
+    {#if title}
+      <h2
+        class="proi-card-title"
+        style:justify-content={closable ? "space-between" : "flex-start"}
+      >
+        {title}
+        {#if closable}
+          <IconButton
+            icon={CloseIcon}
+            variant="ghost"
+            on:click={onClose}
+          />
+        {/if}
+      </h2>
+    {/if}
+    {#if description}
+      <div class="proi-card-description">{description}</div>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .proi-card {
@@ -29,8 +57,11 @@
   }
 
   .proi-card-title {
+    position: relative;
+    display: inline-flex;
     font-size: 16px;
     margin: 0;
+    padding-right: 24px;
   }
 
   .proi-card-description {
@@ -70,5 +101,21 @@
   .data-display.bright {
     background: var(--n0);
     color: var(--n800);
+  }
+
+  /* Close button */
+  .proi-card-title :global(.proi-icon-button) {
+    position: absolute;
+    right: 0;
+    top: 2px;
+  }
+
+  .proi-card-title :global(.proi-icon-button svg path) {
+    stroke: var(--n0);
+  }
+
+  .data-display.bright :global(.proi-icon-button svg path),
+  .data-display.mikado :global(.proi-icon-button svg path) {
+    stroke: var(--n800);
   }
 </style>

--- a/src/lib/card/__stories__/Card.story.md
+++ b/src/lib/card/__stories__/Card.story.md
@@ -1,18 +1,19 @@
 ### Properties
 
-| Property           | Description                                                                    | Type      | Default        |
-| ------------------ | ------------------------------------------------------------------------------ | --------- | -------------- |
-| `title`            | Title of Card component (required)                                             | `string`  | `''`           |
-| `description`      | Description of Card component (required)                                       | `string`  | `''`           |
-| `imageSrc`         | Image source for image variant                                                 | `string`  | `''`           |
-| `imageDescription` | Alt attribute of image                                                         | `string`  | `'Card image'` |
-| `showAction`       | Whether to display the action button or not                                    | `boolean` | `false`        |
-| `actionLabel`      | Specify the label of action button                                             | `string`  | `'Action'`     |
-| `showCancelAction` | Whether to display the action button or not. Works only with `showAction` true | `boolean` | `false`        |
+| Property           | Description                                   | Type      | Default        |
+| ------------------ | --------------------------------------------- | --------- | -------------- |
+| `title`            | Title of Card component (required)            | `string`  | `''`           |
+| `description`      | Description of Card component (required)      | `string`  | `''`           |
+| `imageSrc`         | Image source for image variant                | `string`  | `''`           |
+| `imageDescription` | Alt attribute of image                        | `string`  | `'Card image'` |
+| `closable`         | Wether the Card component is closable or not. | `boolean` | `false`        |
 
 #### Events
 
 | Event name | Description                                        |
 | ---------- | -------------------------------------------------- |
-| `action`   | Dispatched when user click on action button        |
 | `cancel`   | Dispatched when user click on cancel button action |
+
+#### Slots
+
+- use `actions` named slot to display action for the target Card component

--- a/src/lib/card/__stories__/Card.story.md
+++ b/src/lib/card/__stories__/Card.story.md
@@ -2,17 +2,17 @@
 
 | Property           | Description                                   | Type      | Default        |
 | ------------------ | --------------------------------------------- | --------- | -------------- |
-| `title`            | Title of Card component (required)            | `string`  | `''`           |
-| `description`      | Description of Card component (required)      | `string`  | `''`           |
-| `imageSrc`         | Image source for image variant                | `string`  | `''`           |
-| `imageDescription` | Alt attribute of image                        | `string`  | `'Card image'` |
+| `title`            | Title of Card component. (required)           | `string`  | `''`           |
+| `description`      | Description of Card component. (required)     | `string`  | `''`           |
+| `imageSrc`         | Image source for image variant.               | `string`  | `''`           |
+| `imageDescription` | Alt attribute of image.                       | `string`  | `'Card image'` |
 | `closable`         | Wether the Card component is closable or not. | `boolean` | `false`        |
 
 #### Events
 
-| Event name | Description                                        |
-| ---------- | -------------------------------------------------- |
-| `cancel`   | Dispatched when user click on cancel button action |
+| Event name | Description                                 |
+| ---------- | ------------------------------------------- |
+| `close`    | Dispatched when user click on close button. |
 
 #### Slots
 

--- a/src/lib/card/__stories__/Card.story.md
+++ b/src/lib/card/__stories__/Card.story.md
@@ -16,4 +16,4 @@
 
 #### Slots
 
-- use `actions` named slot to display action for the target Card component
+- use `actions` named slot to display actions for the target Card component

--- a/src/lib/card/__stories__/Card.story.svelte
+++ b/src/lib/card/__stories__/Card.story.svelte
@@ -7,8 +7,12 @@
     withImageSource,
     withLongerTitleSource,
     onCloseEventSource,
-    closableSource
+    closableSource,
+    withActionsSlotSource
   } from "./card.source.js";
+  import Button from "../../button/Button.svelte";
+  import Divider from "../../divider/Divider.svelte";
+  import Link from "../../link/Link.svelte";
 
   export let Hst: HstType;
 
@@ -21,7 +25,7 @@
 
 <Hst.Story
   title="Cards/Card"
-  layout={{ type: "grid", width: "50%" }}
+  layout={{ type: "grid", width: "90%" }}
 >
   <Hst.Variant
     title="Default"
@@ -95,6 +99,47 @@
       description="Supporting description for the card goes here like a breeze."
       closable
     />
+  </Hst.Variant>
+
+  <Hst.Variant
+    title="With slot: actions"
+    source={withActionsSlotSource}
+  >
+    <Card
+      title="Title"
+      description="Supporting description for the card goes here like a breeze."
+      closable
+    >
+      <svelte:fragment slot="actions">
+        <Link
+          href="#"
+          title="link"
+        >
+          First
+        </Link>
+        <Divider />
+        <Link
+          href="#"
+          title="link"
+        >
+          Second
+        </Link>
+      </svelte:fragment>
+    </Card>
+    <br />
+    <Card
+      title="Title"
+      description="Supporting description for the card goes here like a breeze."
+      closable
+    >
+      <svelte:fragment slot="actions">
+        <Button variant="ghost">🧪</Button>
+        <Divider />
+        <Button variant="ghost">📦</Button>
+        <Divider />
+        <Button variant="ghost">🧬</Button>
+      </svelte:fragment>
+    </Card>
   </Hst.Variant>
 
   <Hst.Variant

--- a/src/lib/card/__stories__/Card.story.svelte
+++ b/src/lib/card/__stories__/Card.story.svelte
@@ -4,13 +4,10 @@
   import Card from "../Card.svelte";
   import {
     defaultSource,
-    onActionEvent,
-    withAction,
-    withCancelAction,
-    withCustomActionLabel,
-    withImage,
-    withLongerTitle,
-    onCancelEvent
+    withImageSource,
+    withLongerTitleSource,
+    onCloseEventSource,
+    closableSource
   } from "./card.source.js";
 
   export let Hst: HstType;
@@ -19,9 +16,7 @@
   let description: string = "Description";
   let imageSrc: string = "";
   let imageDescription: string = "";
-  let showAction: boolean = false;
-  let actionLabel: string = "Action";
-  let showCancelAction: boolean = false;
+  let closable: boolean = false;
 </script>
 
 <Hst.Story
@@ -44,9 +39,7 @@
       {description}
       {imageDescription}
       {imageSrc}
-      {showAction}
-      {actionLabel}
-      {showCancelAction}
+      {closable}
     />
     <svelte:fragment slot="controls">
       <Hst.Text
@@ -66,25 +59,15 @@
         title="Image description"
       />
       <Hst.Checkbox
-        title="Show action"
-        bind:value={showAction}
+        title="Closable"
+        bind:value={closable}
       />
-      {#if showAction}
-        <Hst.Text
-          bind:value={actionLabel}
-          title="Action label"
-        />
-        <Hst.Checkbox
-          title="Show cancel action"
-          bind:value={showCancelAction}
-        />
-      {/if}
     </svelte:fragment>
   </Hst.Variant>
 
   <Hst.Variant
     title="With longer title"
-    source={withLongerTitle}
+    source={withLongerTitleSource}
   >
     <Card
       title="Lorem ipsum, dolor sit amet consectetur adipisicing elit."
@@ -94,7 +77,7 @@
 
   <Hst.Variant
     title="With image"
-    source={withImage}
+    source={withImageSource}
   >
     <Card
       title="Title"
@@ -104,61 +87,25 @@
   </Hst.Variant>
 
   <Hst.Variant
-    title="With action"
-    source={withAction}
+    title="Closable"
+    source={closableSource}
   >
     <Card
       title="Title"
       description="Supporting description for the card goes here like a breeze."
-      showAction
+      closable
     />
   </Hst.Variant>
 
   <Hst.Variant
-    title="With custom action label"
-    source={withCustomActionLabel}
+    title="on:close event"
+    source={onCloseEventSource}
   >
     <Card
       title="Title"
       description="Supporting description for the card goes here like a breeze."
-      showAction
-      actionLabel="Custom action"
-    />
-  </Hst.Variant>
-
-  <Hst.Variant
-    title="With cancel action"
-    source={withCancelAction}
-  >
-    <Card
-      title="Title"
-      description="Supporting description for the card goes here like a breeze."
-      showAction
-      showCancelAction
-    />
-  </Hst.Variant>
-  <Hst.Variant
-    title="on:action event"
-    source={onActionEvent}
-  >
-    <Card
-      title="Title"
-      description="Supporting description for the card goes here like a breeze."
-      showAction
-      on:action={(e) => logEvent("action", e)}
-    />
-  </Hst.Variant>
-
-  <Hst.Variant
-    title="on:cancel event"
-    source={onCancelEvent}
-  >
-    <Card
-      title="Title"
-      description="Supporting description for the card goes here like a breeze."
-      showAction
-      showCancelAction
-      on:cancel={(e) => logEvent("cancel", e)}
+      closable
+      on:close={(e) => logEvent("cancel", e)}
     />
   </Hst.Variant>
 </Hst.Story>

--- a/src/lib/card/__stories__/FillCard.story.md
+++ b/src/lib/card/__stories__/FillCard.story.md
@@ -1,7 +1,8 @@
 ### Properties
 
-| Property      | Description                                                                                  | Type     | Default  |
-| ------------- | -------------------------------------------------------------------------------------------- | -------- | -------- |
-| `title`       | Title of FillCard component (required)                                                       | `string` | `''`     |
-| `description` | Description of FillCard component (required)                                                 | `string` | `''`     |
-| `variant`     | Variant of FillCard component. Options: `pine, neutral, makido, vivid, flame, tufts, bright` | `string` | `'pine'` |
+| Property      | Description                                                                                  | Type      | Default  |
+| ------------- | -------------------------------------------------------------------------------------------- | --------- | -------- |
+| `title`       | Title of FillCard component (required)                                                       | `string`  | `''`     |
+| `description` | Description of FillCard component (required)                                                 | `string`  | `''`     |
+| `variant`     | Variant of FillCard component. Options: `pine, neutral, makido, vivid, flame, tufts, bright` | `string`  | `'pine'` |
+| `closable`    | Whether the FillCard component is closable or not.                                           | `boolean` | `false`  |

--- a/src/lib/card/__stories__/FillCard.story.md
+++ b/src/lib/card/__stories__/FillCard.story.md
@@ -6,3 +6,9 @@
 | `description` | Description of FillCard component (required)                                                 | `string`  | `''`     |
 | `variant`     | Variant of FillCard component. Options: `pine, neutral, makido, vivid, flame, tufts, bright` | `string`  | `'pine'` |
 | `closable`    | Whether the FillCard component is closable or not.                                           | `boolean` | `false`  |
+
+#### Events
+
+| Event name | Description                                 |
+| ---------- | ------------------------------------------- |
+| `close`    | Dispatched when user click on close button. |

--- a/src/lib/card/__stories__/FillCard.story.svelte
+++ b/src/lib/card/__stories__/FillCard.story.svelte
@@ -3,7 +3,12 @@
   import { dataDisplayVariants } from "../../utils/variants.js";
   import { capitalizeFirstLetter } from "../../utils/string.js";
   import FillCard from "../FillCard.svelte";
-  import { defaultSource, variantFillCard, withLongerTitle } from "./fill-card.source.js";
+  import {
+    closable,
+    defaultSource,
+    variantFillCard,
+    withLongerTitle
+  } from "./fill-card.source.js";
   import type { CardVariant } from "../card.types.js";
 
   export let Hst: HstType;
@@ -48,6 +53,27 @@
         options={dataDisplayVariants.map((x) => ({ label: x, value: x }))}
       />
     </svelte:fragment>
+  </Hst.Variant>
+
+  <Hst.Variant
+    title="With longer title"
+    source={withLongerTitle}
+  >
+    <FillCard
+      title="Lorem ipsum, dolor sit amet consectetur adipisicing elit"
+      description="Supporting description for the card goes here like a breeze."
+    />
+  </Hst.Variant>
+
+  <Hst.Variant
+    title="Closable"
+    source={closable}
+  >
+    <FillCard
+      title="Lorem ipsum"
+      description="Supporting description for the card goes here like a breeze."
+      closable
+    />
   </Hst.Variant>
 
   <Hst.Variant

--- a/src/lib/card/__stories__/card.source.ts
+++ b/src/lib/card/__stories__/card.source.ts
@@ -29,6 +29,21 @@ export const closableSource = `${template}
   closable
 />`;
 
+export const withActionsSlotSource = `${template}
+<Card
+  title="Title"
+  description="Supporting description for the card goes here like a breeze."
+  closable
+>
+  <svelte:fragment slot="actions">
+    <Button variant="ghost">🧪</Button>
+    <Divider />
+    <Button variant="ghost">📦</Button>
+    <Divider />
+    <Button variant="ghost">🧬</Button>
+  </svelte:fragment>
+</Card>`;
+
 export const onCloseEventSource = `${template}
 <Card
   title="Title"

--- a/src/lib/card/__stories__/card.source.ts
+++ b/src/lib/card/__stories__/card.source.ts
@@ -9,55 +9,30 @@ export const defaultSource = `${template}
   description="Supporting description for the card goes here like a breeze."
 />`;
 
-export const withLongerTitle = `${template}
+export const withLongerTitleSource = `${template}
 <Card
   title="Lorem ipsum, dolor sit amet consectetur adipisicing elit."
   description="Supporting description for the card goes here like a breeze."
 />`;
 
-export const withImage = `${template}
+export const withImageSource = `${template}
 <Card
   title="Title"
   description="Supporting description for the card goes here like a breeze."
   imageSrc="https://www.wallart.com/media/catalog/product/cache/871f459736130e239a3f5e6472128962/m/a/marble_1.jpg"
 />`;
 
-export const withAction = `${template}
+export const closableSource = `${template}
 <Card
   title="Title"
   description="Supporting description for the card goes here like a breeze."
-  showAction
+  closable
 />`;
 
-export const withCustomActionLabel = `${template}
+export const onCloseEventSource = `${template}
 <Card
   title="Title"
   description="Supporting description for the card goes here like a breeze."
-  showAction
-  actionLabel="Custom action"
-/>`;
-
-export const withCancelAction = `${template}
-<Card
-  title="Title"
-  description="Supporting description for the card goes here like a breeze."
-  showAction
-  showCancelAction
-/>`;
-
-export const onActionEvent = `${template}
-<Card
-  title="Title"
-  description="Supporting description for the card goes here like a breeze."
-  showAction
-  on:action={() => console.log("action")}
-/>`;
-
-export const onCancelEvent = `${template}
-<Card
-  title="Title"
-  description="Supporting description for the card goes here like a breeze."
-  showAction
-  showCancelAction
-  on:cancel={() => console.log("cancel")}
+  closable
+  on:close={() => console.log("closed")}
 />`;

--- a/src/lib/card/__stories__/fill-card.source.ts
+++ b/src/lib/card/__stories__/fill-card.source.ts
@@ -12,6 +12,14 @@ export const defaultSource = `${template}
 />
 `;
 
+export const closable = `${template}
+<FillCard
+  title="Lorem ipsum"
+  description="Supporting description for the card goes here like a breeze."
+  closable
+/>
+`;
+
 export const withLongerTitle = `${template}
 <FillCard
   title="Lorem ipsum, dolor sit amet consectetur adipisicing elit"

--- a/src/lib/card/__tests__/card.selectors.ts
+++ b/src/lib/card/__tests__/card.selectors.ts
@@ -2,7 +2,6 @@
 export const ROOT = ":scope > div > div";
 export const IMAGE = `${ROOT} > .proi-card-image`;
 export const TITLE = `${ROOT} > h2`;
+export const CLOSE_BUTTON = `${TITLE} > button`;
 export const DESCRIPTION = `${ROOT} > .proi-card-description`;
 export const ACTIONS_CONTAINER = `${ROOT} > .proi-card-actions`;
-export const ACTION_BUTTON = `${ACTIONS_CONTAINER}  > button:nth-child(1)`;
-export const CANCEL_BUTTON = `${ACTIONS_CONTAINER}  > button:nth-child(2)`;

--- a/src/lib/card/__tests__/card.test.ts
+++ b/src/lib/card/__tests__/card.test.ts
@@ -1,15 +1,7 @@
 import { describe, it, vi } from "vitest";
 import { fireEvent, render } from "../../../__tests__/tests.queries.js";
 import Card from "../Card.svelte";
-import {
-  ACTION_BUTTON,
-  ACTIONS_CONTAINER,
-  DESCRIPTION,
-  IMAGE,
-  ROOT,
-  TITLE,
-  CANCEL_BUTTON
-} from "./card.selectors.js";
+import { DESCRIPTION, IMAGE, ROOT, TITLE, CLOSE_BUTTON } from "./card.selectors.js";
 
 describe("Card", () => {
   const title = "Title";
@@ -207,193 +199,72 @@ describe("Card", () => {
     });
   });
 
-  describe("when `showAction` property", () => {
+  describe("when `closable` property", () => {
     describe("is set to `true`", () => {
-      const showAction = true;
+      const closable = true;
 
-      describe("actions container element", () => {
+      describe("close button element", () => {
         it("should be in the document", () => {
           const { getBySelector } = render(Card, {
             props: {
               title,
               description,
-              showAction
+              closable
             }
           });
 
-          expect(getBySelector(ACTIONS_CONTAINER)).toBeInTheDocument();
-        });
-
-        it("should contain `proi-card-actions` class", () => {
-          const { getBySelector } = render(Card, {
-            props: {
-              title,
-              description,
-              showAction
-            }
-          });
-
-          expect(getBySelector(ACTIONS_CONTAINER)).toHaveClass("proi-card-actions");
-        });
-
-        it("should contain 1 child", () => {
-          const { getBySelector } = render(Card, {
-            props: {
-              title,
-              description,
-              showAction
-            }
-          });
-
-          expect(getBySelector(ACTIONS_CONTAINER).childElementCount).toBe(1);
+          expect(getBySelector(CLOSE_BUTTON)).toBeInTheDocument();
         });
       });
 
-      describe("action button element", () => {
-        it("should be in the document", () => {
-          const { getBySelector } = render(Card, {
+      describe("when `click` event is trigered", () => {
+        it("should dispatch `close` event", async () => {
+          const mock = vi.fn();
+          const { component, getBySelector } = render(Card, {
             props: {
               title,
               description,
-              showAction
+              closable
             }
           });
 
-          expect(getBySelector(ACTION_BUTTON)).toBeInTheDocument();
+          component.$on("close", mock);
+
+          await fireEvent.click(getBySelector(CLOSE_BUTTON));
+
+          expect(mock).toHaveBeenCalledTimes(1);
         });
 
-        describe("when click event is triggered", () => {
-          it("should dispatch `action` event", async () => {
-            const mock = vi.fn();
-            const { component, getBySelector } = render(Card, {
+        describe("root element", () => {
+          it("should not be in the document", async () => {
+            const { getBySelector } = render(Card, {
               props: {
                 title,
                 description,
-                showAction
+                closable
               }
             });
 
-            component.$on("action", mock);
+            await fireEvent.click(getBySelector(CLOSE_BUTTON));
 
-            await fireEvent.click(getBySelector(ACTION_BUTTON));
-
-            expect(mock).toHaveBeenCalled();
-          });
-        });
-      });
-
-      describe("and `actionLabel` property", () => {
-        describe("is set", () => {
-          const actionLabel = "custom action";
-
-          describe("action button element", () => {
-            it("should contain `actionLabel` property as innerText", () => {
-              const { getBySelector } = render(Card, {
-                props: {
-                  title,
-                  description,
-                  showAction,
-                  actionLabel
-                }
-              });
-
-              expect(getBySelector(ACTION_BUTTON)).toHaveTextContent(actionLabel);
-            });
-          });
-        });
-
-        describe("is not set", () => {
-          describe("action button element", () => {
-            it("should contain default value of `actionLabel` property as innerText", () => {
-              const { getBySelector } = render(Card, {
-                props: {
-                  title,
-                  description,
-                  showAction
-                }
-              });
-
-              expect(getBySelector(ACTION_BUTTON)).toHaveTextContent("Action");
-            });
-          });
-        });
-      });
-
-      describe("and `showCancelAction` property", () => {
-        describe("is set to `true`", () => {
-          const showCancelAction = true;
-
-          describe("cancel button element", () => {
-            it("should be in the document", () => {
-              const { getBySelector } = render(Card, {
-                props: {
-                  title,
-                  description,
-                  showAction,
-                  showCancelAction
-                }
-              });
-
-              expect(getBySelector(CANCEL_BUTTON)).toBeInTheDocument();
-            });
-
-            describe("when click event is triggered", () => {
-              it("should trigger `cancel` event", async () => {
-                const mock = vi.fn();
-                const { component, getBySelector } = render(Card, {
-                  props: {
-                    title,
-                    description,
-                    showAction,
-                    showCancelAction
-                  }
-                });
-
-                component.$on("cancel", mock);
-
-                await fireEvent.click(getBySelector(CANCEL_BUTTON));
-
-                expect(mock).toHaveBeenCalled();
-              });
-            });
-          });
-        });
-
-        describe("is set to `false`", () => {
-          const showCancelAction = false;
-
-          describe("cancel button element", () => {
-            it("should not be in the document", () => {
-              const { getBySelector } = render(Card, {
-                props: {
-                  title,
-                  description,
-                  showAction,
-                  showCancelAction
-                }
-              });
-
-              expect(() => getBySelector(CANCEL_BUTTON)).toThrowError();
-            });
+            expect(() => getBySelector(ROOT)).toThrowError();
           });
         });
       });
     });
 
     describe("is set to `false`", () => {
-      const showAction = false;
-
-      describe("actions container element", () => {
+      describe("close button element", () => {
         it("should not be in the document", () => {
           const { getBySelector } = render(Card, {
             props: {
               title,
               description,
-              showAction
+              closable: false
             }
           });
 
-          expect(() => getBySelector(ACTIONS_CONTAINER)).toThrowError();
+          expect(() => getBySelector(CLOSE_BUTTON)).toThrowError();
         });
       });
     });

--- a/src/lib/card/__tests__/fill-card.selectors.ts
+++ b/src/lib/card/__tests__/fill-card.selectors.ts
@@ -1,4 +1,5 @@
 /** Component's element(s) selector(s) */
 export const ROOT = ":scope > div > div";
 export const TITLE = `${ROOT} > h2`;
+export const CLOSE_BUTTON = `${TITLE} > button`;
 export const DESCRIPTION = `${ROOT} > .proi-card-description`;

--- a/src/lib/card/__tests__/fill-card.test.ts
+++ b/src/lib/card/__tests__/fill-card.test.ts
@@ -1,132 +1,187 @@
-import { describe } from "vitest";
+import { describe, vi } from "vitest";
 import { render } from "../../../__tests__/tests.queries.js";
-import { TITLE, DESCRIPTION, ROOT } from "./fill-card.selectors.js";
+import { TITLE, DESCRIPTION, ROOT, CLOSE_BUTTON } from "./fill-card.selectors.js";
 import FillCard from "../FillCard.svelte";
 import { dataDisplayVariants } from "../../utils/variants.js";
+import { fireEvent } from "@testing-library/svelte";
 
 describe("FillCard", () => {
-  describe("Card", () => {
-    const title = "Title";
-    const description = "Description";
+  const title = "Title";
+  const description = "Description";
 
-    describe("root element", () => {
-      it("should be in the document", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(ROOT)).toBeInTheDocument();
+  describe("root element", () => {
+    it("should be in the document", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
       });
 
-      it("should contain `proi-card` class", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(ROOT)).toHaveClass("proi-card");
-      });
-
-      it("should contain `data-display` class", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(ROOT)).toHaveClass("data-display");
-      });
+      expect(getBySelector(ROOT)).toBeInTheDocument();
     });
 
-    describe("title element", () => {
-      it("should be in the document", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(TITLE)).toBeInTheDocument();
+    it("should contain `proi-card` class", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
       });
 
-      it("should contain `proi-card-title` class", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(TITLE)).toHaveClass("proi-card-title");
-      });
-
-      it("should contain `title` property as innerText", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(TITLE)).toHaveTextContent(title);
-      });
+      expect(getBySelector(ROOT)).toHaveClass("proi-card");
     });
 
-    describe("description element", () => {
-      it("should be in the document", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(DESCRIPTION)).toBeInTheDocument();
+    it("should contain `data-display` class", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
       });
 
-      it("should contain `proi-card-description` class", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
+      expect(getBySelector(ROOT)).toHaveClass("data-display");
+    });
+  });
 
-        expect(getBySelector(DESCRIPTION)).toHaveClass("proi-card-description");
+  describe("title element", () => {
+    it("should be in the document", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
       });
 
-      it("should contain `description` property as innerText", () => {
-        const { getBySelector } = render(FillCard, {
-          props: {
-            title,
-            description
-          }
-        });
-
-        expect(getBySelector(DESCRIPTION)).toHaveTextContent(description);
-      });
+      expect(getBySelector(TITLE)).toBeInTheDocument();
     });
 
-    describe("when `variant` property", () => {
-      dataDisplayVariants.forEach((variant) => {
-        describe("root element", () => {
-          it(`should contain \`${variant}\` class`, () => {
-            const { getBySelector } = render(FillCard, {
+    it("should contain `proi-card-title` class", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
+      });
+
+      expect(getBySelector(TITLE)).toHaveClass("proi-card-title");
+    });
+
+    it("should contain `title` property as innerText", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
+      });
+
+      expect(getBySelector(TITLE)).toHaveTextContent(title);
+    });
+  });
+
+  describe("description element", () => {
+    it("should be in the document", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
+      });
+
+      expect(getBySelector(DESCRIPTION)).toBeInTheDocument();
+    });
+
+    it("should contain `proi-card-description` class", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
+      });
+
+      expect(getBySelector(DESCRIPTION)).toHaveClass("proi-card-description");
+    });
+
+    it("should contain `description` property as innerText", () => {
+      const { getBySelector } = render(FillCard, {
+        props: {
+          title,
+          description
+        }
+      });
+
+      expect(getBySelector(DESCRIPTION)).toHaveTextContent(description);
+    });
+  });
+
+  describe("when `variant` property", () => {
+    dataDisplayVariants.forEach((variant) => {
+      describe("root element", () => {
+        it(`should contain \`${variant}\` class`, () => {
+          const { getBySelector } = render(FillCard, {
+            props: {
+              title,
+              description,
+              variant
+            }
+          });
+
+          expect(getBySelector(ROOT)).toHaveClass(variant);
+        });
+      });
+    });
+  });
+
+  describe("when `closable` property", () => {
+    describe("is set to `true`", () => {
+      const closable = true;
+
+      describe("close button element", () => {
+        it("should be in the document", () => {
+          const { getBySelector } = render(FillCard, {
+            props: {
+              title,
+              description,
+              closable
+            }
+          });
+
+          expect(getBySelector(CLOSE_BUTTON)).toBeInTheDocument();
+        });
+
+        describe("when `click` event is triggered", () => {
+          it("should dispatch `close` event", async () => {
+            const mock = vi.fn();
+
+            const { component, getBySelector } = render(FillCard, {
               props: {
                 title,
                 description,
-                variant
+                closable
               }
             });
 
-            expect(getBySelector(ROOT)).toHaveClass(variant);
+            component.$on("close", mock);
+
+            await fireEvent.click(getBySelector(CLOSE_BUTTON));
+
+            expect(mock).toHaveBeenCalled();
+          });
+
+          describe("root element", () => {
+            it("should not be in the document", async () => {
+              const { getBySelector } = render(FillCard, {
+                props: {
+                  title,
+                  description,
+                  closable
+                }
+              });
+
+              await fireEvent.click(getBySelector(CLOSE_BUTTON));
+
+              expect(() => getBySelector(ROOT)).toThrowError();
+            });
           });
         });
       });


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Use commitlint for PR title.
- [x] Make sure you are making a pull request to target `dev` branch.

### Short description

Add `closable` prop for `Card` and `FillCard` components. Remove `showAction`, `actionLabel` and `showCancelAction` properties.
